### PR TITLE
Update SurpriseMe README.md

### DIFF
--- a/Surprise_Me_Text_To_Audio_CLI/README.md
+++ b/Surprise_Me_Text_To_Audio_CLI/README.md
@@ -10,8 +10,9 @@ A command line tool to convert random JSON files in this repository to audio
 ## Getting Started
 
 ### Supported OS
-Ubuntu
-Windows 10
+Ubuntu  
+Windows 10  
+macOS  
 
 ### Prerequisites
 


### PR DESCRIPTION
When running on macOS, errors occur with choosing the voice (Python[23023:127218] NSSpeechSynthesizer: [NSSpeechSynthesizer setVoice:] - Voice identifier not found.) however it still runs.